### PR TITLE
Fix/encoding and crlf

### DIFF
--- a/check_blacklist.sh
+++ b/check_blacklist.sh
@@ -37,9 +37,9 @@ check_diff() {
 
 # check local and theblacklist actor-blacklist hash
 check_hash() {
-    local_hash=`cat ${config} | grep actor-black | grep -v "#" | sort | uniq | tr -d " " | ${checker}`
+    local_hash=`cat ${config} | grep actor-black | grep -v "#" | sort | uniq | sed 's/[^a-zA-Z0-9=-]//g' | tr -d '\r' | ${checker}`
     # get hash from table theblacklist
-    chain_hash=`echo "${chain_actor_list}" | sed 's/^/actor-blacklist = /g' | tr -d " " | ${checker}`
+    chain_hash=`echo "${chain_actor_list}" | sed 's/^/actor-blacklist = /g' | sed 's/[^a-zA-Z0-9=-]//g' | tr -d '\r' | ${checker}`
     if [ "${local_hash}" == "${chain_hash}" ];then
         echo "success: ${chain_hash}"
     else

--- a/fetch.sh
+++ b/fetch.sh
@@ -12,4 +12,4 @@ echo "# ===============blacklist config==============="
 
 curl -s $API -X POST -d '{"scope":"theblacklist", "code":"theblacklist", "table":"theblacklist", "json": true, "limit": 100
 }' | \
-  python  -c "import sys, json; rows = json.load(sys.stdin)['rows'];result = ''; l = [('\n\n# from order: %s' % r['order_name'], [('# %s = %s' % (r['type'], a) if r['action'] != 'add' else '%s = %s' % (r['type'], a)) for a in r['accounts']])for r in rows]; a = [i[0] + '\n' + '\n'.join(i[1]) for i in l]; print ''.join(a);"
+  python  -c "import sys, json; rows = json.load(sys.stdin)['rows'];result = ''; l = [('\n\n# from order: %s' % r['order_name'], [('# %s = %s' % (r['type'], a) if r['action'] != 'add' else '%s = %s' % (r['type'], a)) for a in r['accounts']])for r in rows]; a = [i[0] + '\n' + '\n'.join(i[1]) for i in l]; print ''.join(a).encode('utf-8');"

--- a/generate_blacklist_hash.sh
+++ b/generate_blacklist_hash.sh
@@ -4,9 +4,10 @@ echo
 if [ -z "$1" ];then
   echo ERROR:""
   echo "Please specify your config path: ./generate_blacklist_hash.sh PATH_TO_CONFIG"
-  exit
+  exit 1
 else
   CONFIG=$1
+  [ ! -f ${CONFIG} ] && echo "please check config path(${CONFIG})" && exit 1
 fi
 
 UNAME=`uname`

--- a/generate_blacklist_hash.sh
+++ b/generate_blacklist_hash.sh
@@ -12,9 +12,9 @@ fi
 UNAME=`uname`
 
 if [[ $UNAME == 'Darwin' ]]; then
-  md5=`cat $CONFIG | grep actor-black | grep -v "#" | sort | uniq | tr -d " " | shasum -a 256 | awk '{print $1}'`
+  md5=`cat $CONFIG | grep actor-black | grep -v "#" | sort | uniq | sed 's/[^a-zA-Z0-9=-]//g' | tr -d '\r' | shasum -a 256 | awk '{print $1}'`
 else
-  md5=`cat $CONFIG | grep actor-black | grep -v "#" | sort | uniq | tr -d " " | sha256sum | awk '{print $1}'`
+  md5=`cat $CONFIG | grep actor-black | grep -v "#" | sort | uniq | sed 's/[^a-zA-Z0-9=-]//g' | tr -d '\r' | sha256sum | awk '{print $1}'`
 fi
 echo "The sha256sum of your blacklist config is:"
 echo $md5


### PR DESCRIPTION
* hash generation and checking sanitize: filter out more characters from input, including dreaded "CRLF" line-endings (happened to me through "docker exec cat ...")
* fetching: force utf-8 encoding in output to prevent failure when fetch.sh output is redirected to 
* BONUS: fail gracefully if specified file does not exist instead of giving out an invalid SHA!
